### PR TITLE
Change default fit.times

### DIFF
--- a/R/fit_survival.R
+++ b/R/fit_survival.R
@@ -137,7 +137,7 @@
 #'     ylab("Number needed to treat (NNT)")}
 
 
-CFsurvival <- function(time, event, treat, confounders, fit.times=sort(unique(time[time > 0 & time < max(time[event == 1])])), fit.treat=c(0,1), nuisance.options = list(), conf.band=TRUE, conf.level=.95, contrasts = c("surv.diff", "surv.ratio"), verbose=FALSE) {
+CFsurvival <- function(time, event, treat, confounders, fit.times=sort(unique(time[time > 0 & time <= max(time[event == 1])])), fit.treat=c(0,1), nuisance.options = list(), conf.band=TRUE, conf.level=.95, contrasts = c("surv.diff", "surv.ratio"), verbose=FALSE) {
     .args <- mget(names(formals()), sys.frame(sys.nframe()))
 
     # if(is.null(contrasts)) contrasts <- c("surv.diff", "surv.ratio")


### PR DESCRIPTION
Change default fit times to include the maximum time an event occurred.  This matches the behavior used [here](https://github.com/tedwestling/CFsurvival/blob/2ed1e9554de46bf844aa487e1d43b568c6523cbf/R/fit_survival.R#L200)